### PR TITLE
remove readSocket osPriorityNormal - 2 and name thread

### DIFF
--- a/libraries/SocketWrapper/src/MbedClient.cpp
+++ b/libraries/SocketWrapper/src/MbedClient.cpp
@@ -71,7 +71,7 @@ void arduino::MbedClient::configureSocket(Socket *_s) {
   }
   mutex->lock();
   if (reader_th == nullptr) {
-    reader_th = new rtos::Thread(osPriorityNormal - 2);
+    reader_th = new rtos::Thread(osPriorityNormal, OS_STACK_SIZE, nullptr, "readSocket");
     reader_th->start(mbed::callback(this, &MbedClient::readSocket));
   }
   mutex->unlock();


### PR DESCRIPTION
remove osPriorityNormal - 2 and add thread name. The - 2 doesn't work and indeed and priority other than normal seems to hang. Also would like to name the thread (1st pull - please be gentle)